### PR TITLE
Updated version of glassfish.jersey.core to 2.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,12 +142,12 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.19</version>
+      <version>2.31</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.19</version>
+      <version>2.31</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## Issue
[ASE-4434](https://issues.corp.rapid7.com/browse/ASE-4434)

## Description
- updated jersey-server of org.glassfish.jersey.core to 2.31 from 2.19
- updated jersey-client to 2.31 from 2.19
- update to to address XML External Entity risk detected by Snyk against
2.19

## Testing
- unit tests, further testing to be perform with impending release which is from jenkins repo

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
