### PR TITLE
ASE-4496

### DIFF
--- a/src/main/java/com/rapid7/appspider/ApiSerializer.java
+++ b/src/main/java/com/rapid7/appspider/ApiSerializer.java
@@ -4,6 +4,7 @@
 
 package com.rapid7.appspider;
 
+import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -228,4 +229,30 @@ public class ApiSerializer {
                 .allMatch(jsonObject::getBoolean));
     }
 
+    /**
+     * returns a list of ClientIdNamePair objects extracted from given JSONArray
+     * @param clients JSONArray containing items with format { ClientId = String, ClientName = String }
+     * @return on success list of ClientIdNamePairs extracted from clients; otherwise, Optional.empty()
+     */
+    public Optional<List<ClientIdNamePair>> getClientIdNamePairs(JSONArray clients) {
+        if (Objects.isNull(clients))
+            return Optional.empty();
+        List<ClientIdNamePair> pairs = new ArrayList<>();
+        for (Object object : clients) {
+            if ((object instanceof JSONObject)) {
+                JSONObject client = (JSONObject) object;
+                try {
+                    String id = client.getString("ClientId");
+                    String name = client.getString("ClientName");
+                    if (Objects.isNull(id) || id.isEmpty() || Objects.isNull(name) || name.isEmpty())
+                        continue;
+
+                    pairs.add(new ClientIdNamePair(id, name));
+                } catch (JSONException e) {
+                    logger.severe(e.toString());
+                }
+            }
+        }
+        return Optional.of(pairs);
+    }
 }

--- a/src/main/java/com/rapid7/appspider/ContentHelper.java
+++ b/src/main/java/com/rapid7/appspider/ContentHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2003 - 2020 Rapid7, Inc.  All rights reserved.
+ * Copyright © 2003 - 2021 Rapid7, Inc.  All rights reserved.
  */
 
 package com.rapid7.appspider;

--- a/src/main/java/com/rapid7/appspider/ContentHelper.java
+++ b/src/main/java/com/rapid7/appspider/ContentHelper.java
@@ -212,6 +212,11 @@ public class ContentHelper {
                 : Optional.empty();
     }
     private void logResponseFailure(String introduction, HttpResponse response) {
+        if (response == null) {
+            logger.severe("Response is null");
+            return;
+        }
+
         JSONObject error = asJson(response.getEntity()).orElse(new JSONObject());
         try {
             final String errorMessage = error.getString("ErrorMessage");

--- a/src/main/java/com/rapid7/appspider/ContentHelper.java
+++ b/src/main/java/com/rapid7/appspider/ContentHelper.java
@@ -219,8 +219,24 @@ public class ContentHelper {
 
         JSONObject error = asJson(response.getEntity()).orElse(new JSONObject());
         try {
-            final String errorMessage = error.getString("ErrorMessage");
-            final String reason = error.getString("Reason");
+            final String MESSAGE_KEY = "Message";
+
+            String errorMessage;
+            if (error.has("ErrorMessage")) {
+                errorMessage = error.getString("ErrorMessage");
+            } else if (error.has(MESSAGE_KEY)) {
+                errorMessage = error.getString(MESSAGE_KEY);
+            } else {
+                errorMessage = response.getStatusLine().toString();
+            }
+            String reason;
+            if (error.has("Reason")) {
+                reason = error.getString("Reason");
+            } else if (error.has(MESSAGE_KEY)) {
+                reason = error.getString(MESSAGE_KEY);
+            } else {
+                reason = response.getStatusLine().toString();
+            }
             logger.severe(String.format("%s: '%s'.  with reason '%s'", introduction, errorMessage, reason));
         } catch (JSONException e) {
             logger.severe(String.format("%s: %s.%nexception: %s",

--- a/src/main/java/com/rapid7/appspider/EnterpriseClient.java
+++ b/src/main/java/com/rapid7/appspider/EnterpriseClient.java
@@ -4,10 +4,12 @@
 
 package com.rapid7.appspider;
 
+import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 
 public interface EnterpriseClient {
@@ -117,4 +119,12 @@ public interface EnterpriseClient {
      * @return Optional containing InputStream on success; otherwise, Optional.empty()
      */
     Optional<InputStream> getReportZip(String authToken, String scanId);
+
+    /**
+     * gets an array of all name/id pairs of clients that the authorized user can access
+     * @param authToken authorization token required to execute request
+     * @return array of ClientIdNamePair objects representing the id's and names 
+     *         of accessible clients
+     */
+    Optional<List<ClientIdNamePair>> getClientNameIdPairs(String authToken);
 }

--- a/src/main/java/com/rapid7/appspider/EnterpriseClient.java
+++ b/src/main/java/com/rapid7/appspider/EnterpriseClient.java
@@ -6,6 +6,7 @@ package com.rapid7.appspider;
 
 import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
+import com.rapid7.appspider.models.AuthenticationModel;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -21,19 +22,17 @@ public interface EnterpriseClient {
 
     /**
      * calls the /Authentication/Login endpoint with provided details
-     * @param username Username
-     * @param password Password
+     * @param authModel authentication details such as username, password and optionally clientId
      * @return on success Optional containing the authorization token; otherwise empty
      */
-    Optional<String> login(String username, String password);
+    Optional<String> login(AuthenticationModel authModel);
 
     /**
      * calls the /Authentication/Login endpoint with provided details returning true if credentials are valid
-     * @param username Username
-     * @param password Password
+     * @param authModel authentication details such as username, password and optionally clientId
      * @return true if endpoint returns authorization token; otherwise, false
      */
-    boolean testAuthentication(String username, String password);
+    boolean testAuthentication(AuthenticationModel authModel);
 
     /**
      * fetches the names of available engine groups

--- a/src/main/java/com/rapid7/appspider/EnterpriseRestClient.java
+++ b/src/main/java/com/rapid7/appspider/EnterpriseRestClient.java
@@ -4,8 +4,9 @@
 
 package com.rapid7.appspider;
 
+import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
-import freemarker.template.Configuration;
+
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import org.apache.http.message.BasicNameValuePair;
@@ -18,6 +19,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,8 +67,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
 
 
     /**
-     * returns the full URL for the enterprise rest endpoint
-     * @return the full URL for the enterprise rest endpoint
+     * {@inheritDoc}
      */
     @Override
     public String getUrl() {
@@ -75,10 +76,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
 
     private static final String AUTHENTICATION_LOGIN = "/Authentication/Login";
     /**
-     * calls the /Authentication/Login endpoint with provided details
-     * @param username Username
-     * @param password Password
-     * @return on success Optional containing the authorization token; otherwise empty
+     * {@inheritDoc}
      */
     @Override
     public Optional<String> login(String username, String password) {
@@ -105,10 +103,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     }
 
     /**
-     * calls the /Authentication/Login endpoint with provided details returning true if credentials are valid
-     * @param username Username
-     * @param password Password
-     * @return true if endpoint returns authorization token; otherwise, false
+     * {@inheritDoc}
      */
     @Override
     public boolean testAuthentication(String username, String password) {
@@ -118,11 +113,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     // <editor-fold desc="Engine Group APIs">
 
     /**
-     * fetches the names of available engine groups
-     * @param authToken authorization token required to execute request
-     * @return On success an Optional containing an array of Strings
-     *         representing the names of available engine groups;
-     *         otherwise, Optional.empty()
+     * {@inheritDoc}
      */
     @Override
     public Optional<String[]> getEngineGroupNamesForClient(String authToken) {
@@ -132,11 +123,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     }
 
     /**
-     * fetches the unique id of the engine group given by engineGroupName
-     * @param authToken authorization token required to execute request
-     * @param engineGroupName name of the engine to get the id of
-     * @return Optional containing the id of the engine group if found;
-     *         otherwise, Optional.empty()
+     * {@inheritDoc}
      */
     @Override
     public Optional<String> getEngineGroupIdFromName(String authToken, String engineGroupName) {
@@ -160,11 +147,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     // <editor-fold desc="Scan APIs">
 
     /**
-     * starts a new scan using configuration matching configName
-     * @param authToken authorization token required to execute request
-     * @param configName name of the config to run
-     * @return ScanResult containing details on the success of the request and if successful the
-     *         unique id of the scan
+     * {@inheritDoc}
      */
     @Override
     public ScanResult runScanByConfigName(String authToken, String configName) {
@@ -177,10 +160,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     private static final String GET_SCAN_STATUS = "/Scan/GetScanStatus";
     private static final String SCAN_ID = "scanId";
     /**
-     * gets the current status of the scan identified by scanId
-     * @param authToken authorization token required to execute request
-     * @param scanId unique scan identifier of the scan
-     * @return Optional containing current scan status as String on success; Otherwise Optional.empty()
+     * {@inheritDoc}
      */
     @Override
     public Optional<String> getScanStatus(String authToken, String scanId) {
@@ -193,10 +173,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     private static final String IS_SCAN_FINISHED = "/Scan/IsScanFinished";
 
     /**
-     * determines if the scan identified by scanId has finished
-     * @param authToken authorization token required to execute request
-     * @param scanId unique scan identifier of the scan
-     * @return true if scan has finished regardless of how it finished, or false if it hasn't
+     * {@inheritDoc}
      */
     @Override
     public boolean isScanFinished(String authToken, String scanId) {
@@ -205,10 +182,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
 
     private static final String HAS_REPORT = "/Scan/HasReport";
     /**
-     * determines if a scan identified by scanId has a report or not
-     * @param authToken authorization token required to execute request
-     * @param scanId unique scan identifier of the scan
-     * @return true if the scan has a report; otherwise, false
+     * {@inheritDoc}
      */
     @Override
     public boolean hasReport(String authToken, String scanId) {
@@ -249,11 +223,12 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     private static final String SAVE_CONFIG = "/Config/SaveConfig";
 
     /**
-     * calls /Config/GetConfigs endpoint and returns the JSONObject from those results matching configName
+     * calls the /Configs/SaveConfig endpoint using the provided data to create or update a configuration
      * @param authToken authorization token required to execute request
-     * @param configName name of the matching configuration to return
-     * @return Optional containing the JSONObject of the matching configuration on success;
-     *         otherwise, Optional.empty()
+     * @param name name of the scanconfig to save
+     * @param url target URL for the scan
+     * @param engineGroupId unique engine group id for the engine(s) to be used to execute the scan
+     * @return true on success; otherwise, false
      */
     private Optional<JSONObject> getConfigByName(String authToken, String configName) {
         return getConfigs(authToken)
@@ -273,9 +248,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     }
 
     /**
-     * returns String[] of scan config names
-     * @param authToken authorization token required to execute request
-     * @return String[] of all scan config names
+     * {@inheritDoc}
      */
     @Override
     public Optional<String[]> getConfigNames(String authToken) {
@@ -285,19 +258,15 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     }
 
     /**
-     * calls the /Configs/SaveConfig endpoint using the provided data to create or update a configuration
-     * @param authToken authorization token required to execute request
-     * @param name name of the scanconfig to save
-     * @param url target URL for the scan
-     * @param engineGroupId unique engine group id for the engine(s) to be used to execute the scan
-     * @return true on success; otherwise, false
+     * {@inheritDoc}
      */
     @Override
     public boolean saveConfig(String authToken, String name, URL url, String engineGroupId) {
 
         try {
-            Template template = new Configuration().getTemplate(
-            "src/main/java/com/rapid7/appspider/template/scanConfigTemplate.ftl");
+            Template template = FreemarkerConfiguration
+                .getInstance()
+                .getTemplate("scanConfigTemplate.ftl");
 
             String scanConfigXml = apiSerializer.getScanConfigXml(template, name, url);
             return clientService
@@ -331,11 +300,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     private static final String GET_REPORT_ZIP = "/Report/GetReportZip";
 
     /**
-     * gets the vulnerability summary XML as a String
-     * @param authToken authorization token required to execute request
-     * @param scanId unique scan identifier of the scan to provide report for
-     * @return Optional containing the vulnerability summary as XML String on success;
-     *         otherwise, Optional.empty()
+     * {@inheritDoc}
      */
     @Override
     public Optional<String> getVulnerabilitiesSummaryXml(String authToken, String scanId) {
@@ -346,10 +311,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     }
 
     /**
-     * provides InputStream for the request report zip
-     * @param authToken authorization token required to execute request
-     * @param scanId unique scan identifier of the scan to provide report for
-     * @return Optional containing InputStream on success; otherwise, Optional.empty()
+     * {@inheritDoc}
      */
     @Override
     public Optional<InputStream> getReportZip(String authToken, String scanId) {
@@ -357,6 +319,23 @@ public final class EnterpriseRestClient implements EnterpriseClient {
             .buildGetRequestUsingFormUrlEncoding(restEndPointUrl + GET_REPORT_ZIP, authToken, contentHelper.pairFrom(SCAN_ID, scanId))
             .flatMap(clientService::executeEntityRequest)
             .flatMap(contentHelper::getInputStream);
+    }
+
+    // </editor-fold>
+
+    // <editor-fold desc="Config APIs">
+    private static final String GET_CLIENTS = "/Config/GetClients";
+
+    /**
+     * {@inheritDoc}
+     */
+    public Optional<List<ClientIdNamePair>> getClientNameIdPairs(String authToken) {
+        return clientService
+            .buildGetRequestUsingFormUrlEncoding(restEndPointUrl + GET_CLIENTS, authToken)
+            .flatMap(clientService::executeJsonRequest)
+            .filter(apiSerializer::getIsSuccess)
+            .flatMap(clientObjects -> contentHelper.getArrayFrom(clientObjects, "Clients"))
+            .flatMap(apiSerializer::getClientIdNamePairs);
     }
 
     // </editor-fold>

--- a/src/main/java/com/rapid7/appspider/EnterpriseRestClient.java
+++ b/src/main/java/com/rapid7/appspider/EnterpriseRestClient.java
@@ -13,7 +13,6 @@ import freemarker.template.TemplateException;
 
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
-import org.jfree.util.Log;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -89,10 +88,6 @@ public final class EnterpriseRestClient implements EnterpriseClient {
         if (authModel == null) {
             throw new IllegalArgumentException();
         }
-
-        Log.info("name: " + authModel.getUsername());
-        Log.info("pass: " + authModel.getPassword());
-        Log.info("had id: " + authModel.hasClientId());
 
         try {
             final StringEntity contentEntity = authModel.hasClientId()
@@ -335,7 +330,7 @@ public final class EnterpriseRestClient implements EnterpriseClient {
     // </editor-fold>
 
     // <editor-fold desc="Config APIs">
-    private static final String GET_CLIENTS = "/Config/GetClients";
+    private static final String GET_CLIENTS = "/Client/GetClients";
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/rapid7/appspider/FreemarkerConfiguration.java
+++ b/src/main/java/com/rapid7/appspider/FreemarkerConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2003 - 2020 Rapid7, Inc.  All rights reserved.
+ */
+
+package com.rapid7.appspider;
+
+import java.io.IOException;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+
+/**
+ * Singleton container wrapping Configuration class which should itself be used
+ * as a singleton
+ * 
+ * <p>
+ * using a wrapper to provide additional initialization 
+ * </p>
+ */
+class FreemarkerConfiguration {
+    private static FreemarkerConfiguration instance;
+    private final Configuration configuration;
+
+    /**
+     * get the singelton instance, initializing it if necessary
+     */
+    public static FreemarkerConfiguration getInstance() {
+        if (instance == null) {
+            synchronized(FreemarkerConfiguration.class) {
+                instance = new FreemarkerConfiguration();
+            }
+        }
+        return instance;
+    }
+    /**
+     * Gets a template using name {@code template} in call to inner {@code Configuration}
+     * @param template name of the template to get
+     * @return Template  matching {@code template}
+     * @throws IOException if call to {@code Configuration.getTemplate} throws
+     */
+    public Template getTemplate(String template) throws IOException {
+        return configuration.getTemplate(template);
+    }
+
+    private FreemarkerConfiguration() {
+        configuration = new Configuration(Configuration.VERSION_2_3_30);
+        configuration.setClassForTemplateLoading(EnterpriseRestClient.class, "template");
+    }
+}

--- a/src/main/java/com/rapid7/appspider/LoggerFacade.java
+++ b/src/main/java/com/rapid7/appspider/LoggerFacade.java
@@ -9,4 +9,5 @@ public interface LoggerFacade {
     void info(String message);
     void warn(String message);
     void severe(String message);
+    void verbose(String message);
 }

--- a/src/main/java/com/rapid7/appspider/PrintStreamLoggerFacade.java
+++ b/src/main/java/com/rapid7/appspider/PrintStreamLoggerFacade.java
@@ -33,4 +33,8 @@ public class PrintStreamLoggerFacade implements LoggerFacade {
     public void severe(String message) {
         logger.log(Level.SEVERE, message);
     }
+    @Override
+    public void verbose(String message) {
+        logger.log(Level.FINE, message);
+    }
 }

--- a/src/main/java/com/rapid7/appspider/Report.java
+++ b/src/main/java/com/rapid7/appspider/Report.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2003 - 2020 Rapid7, Inc.  All rights reserved.
+ * Copyright © 2003 - 2021 Rapid7, Inc.  All rights reserved.
  */
 
 package com.rapid7.appspider;
@@ -16,6 +16,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.Optional;
+
+import com.rapid7.appspider.models.AuthenticationModel;
 
 public class Report {
 
@@ -39,7 +41,7 @@ public class Report {
         this.log = log;
     }
 
-    public boolean saveReport(String username, String password, String scanId, FilePath directory) {
+    public boolean saveReport(AuthenticationModel authModel, String scanId, FilePath directory) {
 
         if (Objects.isNull(directory))
             throw new IllegalArgumentException("directory cannot be null or empty");
@@ -48,7 +50,7 @@ public class Report {
         String reportFolder = Paths.get("" + directory.getParent(), directory.getBaseName()).toString();
 
         log.println("Generating xml report and downloading report zip file to:" + directory);
-        Optional<String> maybeAuthToken = client.login(username, password);
+        Optional<String> maybeAuthToken = client.login(authModel);
         if (!maybeAuthToken.isPresent()) {
             log.println("Unauthorized: unable to retrieve vulnerabilities summary and report.zip");
             return false;

--- a/src/main/java/com/rapid7/appspider/Scan.java
+++ b/src/main/java/com/rapid7/appspider/Scan.java
@@ -1,10 +1,11 @@
 /*
- * Copyright © 2003 - 2020 Rapid7, Inc.  All rights reserved.
+ * Copyright © 2003 - 2021 Rapid7, Inc.  All rights reserved.
  */
 
 package com.rapid7.appspider;
 
 import com.rapid7.appspider.datatransferobjects.ScanResult;
+import com.rapid7.appspider.models.AuthenticationModel;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -44,8 +45,8 @@ public class Scan {
         return id;
     }
 
-    public boolean process(String username, String password) throws InterruptedException {
-        Optional<String> maybeAuthToken = client.login(username, password);
+    public boolean process(AuthenticationModel authModel) throws InterruptedException {
+        Optional<String> maybeAuthToken = client.login(authModel);
         if (!maybeAuthToken.isPresent()) {
             log.println(UNAUTHORIZED_ERROR);
             return false;
@@ -67,9 +68,9 @@ public class Scan {
             return true;
         }
 
-        waitForScanCompletion(runResult.getScanId(), username, password);
+        waitForScanCompletion(runResult.getScanId(), authModel);
 
-        maybeAuthToken = client.login(username, password);
+        maybeAuthToken = client.login(authModel);
         if (!maybeAuthToken.isPresent()) {
             log.println(UNAUTHORIZED_ERROR);
             return false;
@@ -125,12 +126,12 @@ public class Scan {
         }
     }
 
-    private void waitForScanCompletion(String scanId, String username, String password) throws InterruptedException {
+    private void waitForScanCompletion(String scanId, AuthenticationModel authModel) throws InterruptedException {
         String scanStatus;
         try {
             do {
                 TimeUnit.SECONDS.sleep(settings.getStatusPollTime());
-                scanStatus = getStatus(scanId, username, password)
+                scanStatus = getStatus(scanId, authModel)
                         .orElseGet(this::failedStatusRequest);
                 log.println("Scan status: [" + scanStatus +"]");
 
@@ -141,8 +142,8 @@ public class Scan {
             throw e;
         }
     }
-    private Optional<String> getStatus(String scanId, String username, String password) {
-        Optional<String> authToken = client.login(username, password);
+    private Optional<String> getStatus(String scanId, AuthenticationModel authModel) {
+        Optional<String> authToken = client.login(authModel);
         if (!authToken.isPresent()) {
             log.println(UNAUTHORIZED_ERROR);
             return Optional.empty();

--- a/src/main/java/com/rapid7/appspider/datatransferobjects/ClientIdNamePair.java
+++ b/src/main/java/com/rapid7/appspider/datatransferobjects/ClientIdNamePair.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2003 - 2021 Rapid7, Inc.  All rights reserved.
+ */
+
+package com.rapid7.appspider.datatransferobjects;
+
+public final class ClientIdNamePair {
+
+    private final String id;
+    private final String name;
+
+    public ClientIdNamePair(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/com/rapid7/appspider/models/AuthenticationModel.java
+++ b/src/main/java/com/rapid7/appspider/models/AuthenticationModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2003 - 2021 Rapid7, Inc.  All rights reserved.
+ */
+
+package com.rapid7.appspider.models;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Storage class containing all the information need to authenticate
+ */
+public class AuthenticationModel {
+
+    private final String username;
+    private final String password;
+    private final Optional<String> clientId;
+
+    /**
+     * instantiates a new instance of the {@code AuthenticationModel} class with no client Id
+     */
+    public AuthenticationModel(String username, String password) {
+        this(username, password, Optional.empty());
+    }
+
+    /**
+     * instantiates a new instance of the {@code AuthenticationModel} class ensuring that
+     * username and password are both non-null and non-empty
+     */
+    public AuthenticationModel(String username, String password, Optional<String> clientId) {
+        if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
+        this.username = username;
+        this.password = password;
+        this.clientId = clientId;
+    }
+
+    /**
+     * gets the password value
+     * @return password as a {@code Secret}
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Get the username value
+     * @return username as a String
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Returns whether this object contains a clientId or not
+     * 
+     * <p>
+     * should be called prior to {@code getClientId} to ensure a value is present,
+     * otherwise an exception may occur
+     * </p>
+     * @return
+     */
+    public boolean hasClientId() {
+        return clientId.isPresent();
+    }
+
+    /**
+     * Gets the client id if present; otherwise throws a {@code NoSuchElementException}
+     * @return the client Id if present
+     * @throws NoSuchElementException if this instance does not have a clientId
+     */
+    public String getClientId() throws NoSuchElementException {
+        return clientId.orElseThrow(NoSuchElementException::new);
+    }
+
+
+}

--- a/src/main/java/com/rapid7/jenkinspider/PostBuildScan.java
+++ b/src/main/java/com/rapid7/jenkinspider/PostBuildScan.java
@@ -183,6 +183,7 @@ public class PostBuildScan extends Notifier {
         private String[] scanConfigNames;
         private String[] scanConfigEngines;
         private String appSpiderClientId;
+        private String appSpiderClientName;
         private Optional<Map<String, String>> clientIdToNames;
         private static final String INVALID_CREDENTIALS = "Invalid username / password combination";
 
@@ -271,6 +272,20 @@ public class PostBuildScan extends Notifier {
             this.appSpiderClientId = appSpiderClientId;
         }
 
+        public String getAppSpiderClientName() {
+            return appSpiderClientName;
+        }
+
+        public void setAppSpiderClientName(String appSpiderClientName) {
+            this.appSpiderClientName = appSpiderClientName;
+            if (!this.clientIdToNames.isPresent())
+                return;
+            Map<String, String> idToNames = clientIdToNames.get();
+
+            String clientId = idToNames.getOrDefault(appSpiderClientName, "NOT-FOUND");
+            if (!clientId.equals("NOT-FOUND"))
+                setAppSpiderClientId(clientId);
+        }
 
         public AuthenticationModel buildAuthenticationModel() {
 

--- a/src/main/java/com/rapid7/jenkinspider/PostBuildScan.java
+++ b/src/main/java/com/rapid7/jenkinspider/PostBuildScan.java
@@ -54,9 +54,9 @@ public class PostBuildScan extends Notifier {
     private final String scanConfigEngineGroupName;
 
     @DataBoundConstructor
-    @SuppressWarnings({"java:S107"})
-    public PostBuildScan(String clientName, String configName, String reportName, Boolean enableScan, Boolean generateReport,
-            String scanConfigName, String scanConfigUrl, String scanConfigEngineGroupName) {
+    @SuppressWarnings({ "java:S107" })
+    public PostBuildScan(String clientName, String configName, String reportName, Boolean enableScan,
+            Boolean generateReport, String scanConfigName, String scanConfigUrl, String scanConfigEngineGroupName) {
         this.clientName = clientName;
         this.configName = configName;
         this.reportName = reportName;
@@ -187,6 +187,7 @@ public class PostBuildScan extends Notifier {
         private String appSpiderUsername;
         private Secret appSpiderPassword;
         private boolean appSpiderAllowSelfSignedCertificate;
+        private boolean appSpiderEnableMultiClientOrSysAdmin;
         private String[] scanConfigNames;
         private String[] scanConfigEngines;
         private String appSpiderClientId;
@@ -262,6 +263,14 @@ public class PostBuildScan extends Notifier {
         public void setAppSpiderAllowSelfSignedCertificate(boolean appSpiderAllowSelfSignedCertificate) {
             this.appSpiderAllowSelfSignedCertificate = appSpiderAllowSelfSignedCertificate;
         }
+        public boolean isAppSpiderEnableMultiClientOrSysAdmin() {
+            return appSpiderEnableMultiClientOrSysAdmin;
+        }
+
+        public void setAppSpiderEnableMultiClientOrSysAdmin(boolean appSpiderAllowMultiClientOrSysAdmin) {
+            this.appSpiderEnableMultiClientOrSysAdmin = appSpiderAllowMultiClientOrSysAdmin;
+        }
+
 
         public String[] getScanConfigNames() {
             return scanConfigNames.clone();
@@ -294,7 +303,7 @@ public class PostBuildScan extends Notifier {
         }
 
         public AuthenticationModel buildAuthenticationModel() {
-            return appSpiderClientId != null && !appSpiderClientId.isEmpty()
+            return appSpiderClientId != null && !appSpiderClientId.isEmpty() && appSpiderEnableMultiClientOrSysAdmin
                 ? new AuthenticationModel(appSpiderUsername, Secret.toString(appSpiderPassword), Optional.of(appSpiderClientId))
                 : new AuthenticationModel(appSpiderUsername, Secret.toString(appSpiderPassword), Optional.empty());
         }
@@ -372,8 +381,9 @@ public class PostBuildScan extends Notifier {
          */
         public ListBoxModel doFillConfigNameItems(@QueryParameter String clientName) {
 
-            if (clientName == null || clientName.equals(CLIENT_NAME_PLACEHOLDER_TEXT) || !clientIdToNames.isPresent())
-                return new ListBoxModel();
+            if (clientName == null || clientName.equals(CLIENT_NAME_PLACEHOLDER_TEXT) || !clientIdToNames.isPresent()){
+                return buildListBoxModel("[Select an engine group name]", new String[0]);
+            }
 
             appSpiderClientId = "";
             if (clientIdToNames.get().containsKey(clientName)) {
@@ -409,7 +419,7 @@ public class PostBuildScan extends Notifier {
          * @param password Password used for authentication
          * @return FormValidation result of the credentials test
          */
-        public FormValidation doTestCredentials(@QueryParameter("appSpiderAllowSelfSignedCertificate") final boolean allowSelfSignedCertificate,
+        public FormValidation doTestCredentials(@QueryParameter("appSpiderAllowSelfSignedCertificate") final boolean allowSelfSignedCertificate,                                                
                                                 @QueryParameter("appSpiderEntUrl") final String appSpiderEntUrl,
                                                 @QueryParameter("appSpiderUsername") final String username,
                                                 @QueryParameter("appSpiderPassword") final Secret password) {

--- a/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/config.jelly
+++ b/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/config.jelly
@@ -10,6 +10,9 @@
     When submitted, it will be passed to the corresponding constructor parameter.
   -->
   <f:section>
+    <f:entry field="clientName" title="Client Name" >
+      <f:select default="Loading list of client names..."/>
+    </f:entry>
     <f:entry field="configName" title="Scan configuration" >
       <f:select default="Loading list of scan configurations..."/>
     </f:entry>
@@ -22,32 +25,6 @@
     <f:entry field="generateReport" title="Obtain the report after the scan finished?">
       <f:checkbox checked="true" />
     </f:entry>
-
-    <!--
-      Create an advance section to create new scan config.
-      No need to go to the NTO Enterprise site
-    -->
-
-    <!-- Temporarily removing this functionality
-    <f:advanced title="Create new scan configuration">
-      <f:section title="Create new scan configuration" >
-        <f:entry field="disclaimer" title="Note: This will overwrite your current scan config selection" >
-          <f:label/>
-        </f:entry>
-        <f:entry field="scanConfigName" title="Name">
-          <f:textbox default=""/>
-        </f:entry>
-        <f:entry field="scanConfigUrl" title="Url">
-          <f:textbox default=""/>
-        </f:entry>
-        <f:entry field="scanConfigEngineGroupName" title="Scan Engine Group">
-          <f:select default="Loading list of scan engine groups..."/>
-        </f:entry>
-        <f:validateButton
-          title="Validate" method="validateNewScanConfig" with="scanConfigName,scanConfigUrl" />
-       </f:section>
-    </f:advanced>
-    -->
 
   </f:section>
 </j:jelly>

--- a/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/global.jelly
+++ b/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/global.jelly
@@ -10,6 +10,9 @@
   <f:entry field="appSpiderAllowSelfSignedCertificate" title="Allow Self-Signed Certificates">
     <f:checkbox />
   </f:entry>
+  <f:entry field="appSpiderEnableMultiClientOrSysAdmin" title="Enable Multi-Client/System-Admin support (Required 3.8.227 or above)">
+    <f:checkbox />
+  </f:entry>
   <f:section title="AppSpider Credentials">
     <f:entry field="appSpiderUsername" title="Username">
       <f:textbox />

--- a/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-clientName.html
+++ b/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-clientName.html
@@ -1,0 +1,7 @@
+<div>
+    <p>The drop down list shows all available clients.</p>
+    <p>
+    For Multi-Client/System-Admin users 3.8.227 is required and support enabled in global (Jenkins) configuration;
+    when multiple clients are listed the config drop down will update based on the selection here.
+    </p>
+</div>

--- a/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-configName.html
+++ b/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-configName.html
@@ -1,3 +1,3 @@
 <div>
-    <p>The drop down list shows all available scan configuration available</p>
+    <p>The drop down list shows all available scan configurations</p>
 </div>

--- a/src/test/java/com/rapid7/appspider/EnterpriseClientTestContext.java
+++ b/src/test/java/com/rapid7/appspider/EnterpriseClientTestContext.java
@@ -39,7 +39,7 @@ public class EnterpriseClientTestContext implements AutoCloseable {
     private static final String SAVE_CONFIG = "/Config/SaveConfig";
     private static final String GET_VULNERABILITIES_SUMMARY = "/Report/GetVulnerabilitiesSummaryXml";
     private static final String GET_REPORT_ZIP = "/Report/GetReportZip";
-    private static final String GET_CLIENTS = "/Config/GetClients";
+    private static final String GET_CLIENTS = "/Client/GetClients";
 
     private final LoggerFacade mockLogger;
     private final ContentHelper mockContentHelper;

--- a/src/test/java/com/rapid7/appspider/EnterpriseRestClientTest.java
+++ b/src/test/java/com/rapid7/appspider/EnterpriseRestClientTest.java
@@ -2,6 +2,8 @@ package com.rapid7.appspider;
 
 import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
+import com.rapid7.appspider.models.AuthenticationModel;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +33,7 @@ class EnterpriseRestClientTest {
     @Test
     void testAuthenticationReturnsTrueWhenCredentialsAreValid() throws IOException {
         context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
-
-        assertTrue(context.getEnterpriseClient().testAuthentication("wolf359", "pa55word"));
+        assertTrue(context.getEnterpriseClient().testAuthentication(new AuthenticationModel("wolf359", "pa55word")));
     }
 
     @Test
@@ -40,26 +41,26 @@ class EnterpriseRestClientTest {
         context.arrangeExpectedValues(false).configureLogin(false).configureEnterpriseClient();
 
         // act and assert
-        assertFalse(context.getEnterpriseClient().testAuthentication("wolf359", "pa55word"));
+        assertFalse(context.getEnterpriseClient().testAuthentication(new AuthenticationModel("wolf359", "pa55word")));
     }
 
     @Test
     void loginHasTokenWhenCredentialsAreValid() throws IOException {
         context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
-        assertTrue(context.getEnterpriseClient().login("wolf359", "pa55word").isPresent());
+        assertTrue(context.getEnterpriseClient().login(new AuthenticationModel("wolf359", "pa55word")).isPresent());
     }
 
     @Test
     void loginTokenHasExpectedValueWhenCredentialsAreValid() throws IOException {
         context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
-        Optional<String> actualToken = context.getEnterpriseClient().login("wolf359", "pa55word");
+        Optional<String> actualToken = context.getEnterpriseClient().login(new AuthenticationModel("wolf359", "pa55word"));
         assertEquals(context.getExpectedAuthToken(), actualToken.get());
     }
 
     @Test
     void loginTokenNotPresentWhenCredentialsAreInvalid() throws IOException {
         context.arrangeExpectedValues(false).configureLogin(false).configureEnterpriseClient();
-        assertFalse(context.getEnterpriseClient().login("wolf359", "pa55word").isPresent());
+        assertFalse(context.getEnterpriseClient().login(new AuthenticationModel("wolf359", "pa55word")).isPresent());
     }
 
     @Test

--- a/src/test/java/com/rapid7/appspider/EnterpriseRestClientTest.java
+++ b/src/test/java/com/rapid7/appspider/EnterpriseRestClientTest.java
@@ -1,5 +1,6 @@
 package com.rapid7.appspider;
 
+import com.rapid7.appspider.datatransferobjects.ClientIdNamePair;
 import com.rapid7.appspider.datatransferobjects.ScanResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,112 +30,94 @@ class EnterpriseRestClientTest {
 
     @Test
     void testAuthenticationReturnsTrueWhenCredentialsAreValid() throws IOException {
-        context
-            .arrangeExpectedValues(true)
-            .configureLogin(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
 
         assertTrue(context.getEnterpriseClient().testAuthentication("wolf359", "pa55word"));
     }
+
     @Test
     void testAuthenticationReturnsFalseWhenCredentialsAreInvalid() throws IOException {
-        context
-            .arrangeExpectedValues(false)
-            .configureLogin(false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(false).configureLogin(false).configureEnterpriseClient();
 
         // act and assert
         assertFalse(context.getEnterpriseClient().testAuthentication("wolf359", "pa55word"));
     }
+
     @Test
     void loginHasTokenWhenCredentialsAreValid() throws IOException {
-        context
-            .arrangeExpectedValues(true)
-            .configureLogin(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
         assertTrue(context.getEnterpriseClient().login("wolf359", "pa55word").isPresent());
     }
+
     @Test
     void loginTokenHasExpectedValueWhenCredentialsAreValid() throws IOException {
-        context
-            .arrangeExpectedValues(true)
-            .configureLogin(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(true).configureLogin(true).configureEnterpriseClient();
         Optional<String> actualToken = context.getEnterpriseClient().login("wolf359", "pa55word");
         assertEquals(context.getExpectedAuthToken(), actualToken.get());
     }
+
     @Test
     void loginTokenNotPresentWhenCredentialsAreInvalid() throws IOException {
-        context
-            .arrangeExpectedValues(false)
-            .configureLogin(false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(false).configureLogin(false).configureEnterpriseClient();
         assertFalse(context.getEnterpriseClient().login("wolf359", "pa55word").isPresent());
     }
 
     @Test
     void getEngineGroupIdForNameIsPresentWhenNameIsFound() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetAllEngineGroups(true)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetAllEngineGroups(true).configureEnterpriseClient();
 
-        Optional<String> engineId = context.getEnterpriseClient().getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
+        Optional<String> engineId = context.getEnterpriseClient()
+                .getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
 
         assertTrue(engineId.isPresent());
     }
+
     @Test
     void getEngineGroupIdForNameCorrectResultReturnedWhenNameIsFound() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetAllEngineGroups(true)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetAllEngineGroups(true).configureEnterpriseClient();
 
-        Optional<String> engineId = context.getEnterpriseClient().getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
+        Optional<String> engineId = context.getEnterpriseClient()
+                .getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
 
         assertEquals(context.getFirstEngineId(), engineId.get());
     }
+
     @Test
     void getEngineGroupIdForNameIsNotPresentWhenNameIsNotFound() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetAllEngineGroups(true)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetAllEngineGroups(true).configureEnterpriseClient();
 
-        Optional<String> engineId = context.getEnterpriseClient().getEngineGroupIdFromName(context.getExpectedAuthToken(), "nameNotFound");
+        Optional<String> engineId = context.getEnterpriseClient()
+                .getEngineGroupIdFromName(context.getExpectedAuthToken(), "nameNotFound");
 
         assertFalse(engineId.isPresent());
     }
+
     @Test
     void getEngineGroupIdForNameIsNotPresentWhenApiCallFails() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetAllEngineGroups(false)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetAllEngineGroups(false).configureEnterpriseClient();
 
-        Optional<String> engineId = context.getEnterpriseClient().getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
+        Optional<String> engineId = context.getEnterpriseClient()
+                .getEngineGroupIdFromName(context.getExpectedAuthToken(), context.getFirstEngineName());
 
         assertFalse(engineId.isPresent());
     }
+
     @Test
     void getEngineGroupNamesForClientIsPresent() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetEngineGroupsForClient(true)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetEngineGroupsForClient(true).configureEnterpriseClient();
 
-        Optional<String[]> engineGroupNames = context.getEnterpriseClient().getEngineGroupNamesForClient(context.getExpectedAuthToken());
+        Optional<String[]> engineGroupNames = context.getEnterpriseClient()
+                .getEngineGroupNamesForClient(context.getExpectedAuthToken());
 
         assertTrue(engineGroupNames.isPresent());
     }
+
     @Test
     void getEngineGroupNamesForClientCorrectResultReturned() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetEngineGroupsForClient(true)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetEngineGroupsForClient(true).configureEnterpriseClient();
 
-        Optional<String[]> engineGroupNames = context.getEnterpriseClient().getEngineGroupNamesForClient(context.getExpectedAuthToken());
+        Optional<String[]> engineGroupNames = context.getEnterpriseClient()
+                .getEngineGroupNamesForClient(context.getExpectedAuthToken());
 
         List<String> expected = Arrays.asList(context.getEngineGroupNames());
         List<String> actual = Arrays.asList(engineGroupNames.get());
@@ -142,182 +125,162 @@ class EnterpriseRestClientTest {
         Collections.sort(actual);
         assertArrayEquals(expected.toArray(), actual.toArray());
     }
+
     @Test
     void getEngineGroupNamesForClientIsNotPresentWhenApiCallFails() throws IOException {
-        context
-                .arrangeExpectedValues()
-                .configureGetEngineGroupsForClient(false)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetEngineGroupsForClient(false).configureEnterpriseClient();
 
-        Optional<String[]> engineGroupNames = context.getEnterpriseClient().getEngineGroupNamesForClient(context.getExpectedAuthToken());
+        Optional<String[]> engineGroupNames = context.getEnterpriseClient()
+                .getEngineGroupNamesForClient(context.getExpectedAuthToken());
 
         assertFalse(engineGroupNames.isPresent());
     }
 
     @Test
     void runScanConfigByNameIsSuccessWhenConfigFoundAndScanCreated() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureGetConfigs(true)
-            .configureRunScanByConfigId(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetConfigs(true).configureRunScanByConfigId(true)
+                .configureEnterpriseClient();
 
-        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(), context.getConfigName());
+        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(),
+                context.getConfigName());
 
         assertTrue(scanResult.isSuccess());
     }
+
     @Test
     void runScanConfigByNameHasScanIdWhenConfigFoundAndScanCreated() throws IOException {
-        context
-            .arrangeExpectedValues(true)
-            .configureGetConfigs(true)
-            .configureRunScanByConfigId(true)
-            .configureEnterpriseClient();
-        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(), context.getConfigName());
+        context.arrangeExpectedValues(true).configureGetConfigs(true).configureRunScanByConfigId(true)
+                .configureEnterpriseClient();
+        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(),
+                context.getConfigName());
 
         assertEquals(context.getExpectedScanId(), scanResult.getScanId());
     }
+
     @Test
     void runScanConfigByNameIsFailWhenConfigNotFound() throws IOException {
-        context
-                .arrangeExpectedValues(true)
-                .configureGetConfigs(false)
-                .configureRunScanByConfigId(true)
+        context.arrangeExpectedValues(true).configureGetConfigs(false).configureRunScanByConfigId(true)
                 .configureEnterpriseClient();
 
-        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(), context.getConfigName());
+        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(),
+                context.getConfigName());
 
         assertFalse(scanResult.isSuccess());
     }
+
     @Test
     void runScanConfigByNameIsFailWhenConfigFoundButRunFails() throws IOException {
-        context
-            .arrangeExpectedValues(true)
-            .configureGetConfigs(true)
-            .configureRunScanByConfigId(false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues(true).configureGetConfigs(true).configureRunScanByConfigId(false)
+                .configureEnterpriseClient();
 
-        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(), context.getConfigName());
+        ScanResult scanResult = context.getEnterpriseClient().runScanByConfigName(context.getExpectedAuthToken(),
+                context.getConfigName());
 
         assertFalse(scanResult.isSuccess());
     }
+
     @Test
     void getScanStatusIsPresentWhenApiCallSuceeds() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureGetScanStatus(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetScanStatus(true).configureEnterpriseClient();
 
-        Optional<String> status = context.getEnterpriseClient().getScanStatus(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<String> status = context.getEnterpriseClient().getScanStatus(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertTrue(status.isPresent());
     }
+
     @Test
     void isScanFinishedIsTrueWhenResultAndIsSuccessAreTrue() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureIsScanFinished(true, true, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureIsScanFinished(true, true, true).configureEnterpriseClient();
 
-        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertTrue(isFinished);
     }
+
     @Test
     void isScanFinishedIsFalseWhenResultIsFalseAndIsSuccessIsTrue() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureIsScanFinished(true, true, false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureIsScanFinished(true, true, false).configureEnterpriseClient();
 
-        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(isFinished);
     }
+
     @Test
     void isScanFinishedIsFalseWhenResultIsTrueAndIsSuccessIsFalse() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureIsScanFinished(true, false, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureIsScanFinished(true, false, true).configureEnterpriseClient();
 
-        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(isFinished);
     }
+
     @Test
     void isScanFinishedIsFalseWhenApiCallFails() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureIsScanFinished(false, true, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureIsScanFinished(false, true, true).configureEnterpriseClient();
 
-        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean isFinished = context.getEnterpriseClient().isScanFinished(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(isFinished);
     }
+
     @Test
     void hasReportIsTrueWhenResultAndIsSuccessAreTrue() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureHasReport(true, true, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureHasReport(true, true, true).configureEnterpriseClient();
 
-        boolean isFinished = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean isFinished = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertTrue(isFinished);
     }
+
     @Test
     void hasReportIsFalseWhenResultIsFalseAndIsSuccessIsTrue() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureHasReport(true, true, false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureHasReport(true, true, false).configureEnterpriseClient();
 
-        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(hasReport);
     }
+
     @Test
     void hasReportIsFalseWhenResultIsTrueAndIsSuccessIsFalse() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureHasReport(true, false, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureHasReport(true, false, true).configureEnterpriseClient();
 
-        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(hasReport);
     }
+
     @Test
     void hasReportIsFalseWhenApiCallFails() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureHasReport(false, true, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureHasReport(false, true, true).configureEnterpriseClient();
 
-        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(), context.getExpectedScanId());
+        boolean hasReport = context.getEnterpriseClient().hasReport(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(hasReport);
     }
 
     @Test
     void getConfigsIsPresentWhenApiCallSucceeds() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureGetConfigs(true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetConfigs(true).configureEnterpriseClient();
 
         Optional<String[]> configs = context.getEnterpriseClient().getConfigNames(context.getExpectedAuthToken());
 
         assertTrue(configs.isPresent());
     }
+
     @Test
     void getConfigsIsNotPresentWhenApiCallFails() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureGetConfigs(false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetConfigs(false).configureEnterpriseClient();
 
         Optional<String[]> configs = context.getEnterpriseClient().getConfigNames(context.getExpectedAuthToken());
 
@@ -326,15 +289,10 @@ class EnterpriseRestClientTest {
 
     @Test
     void saveConfigIsTrueWhenResultIsSuccess() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureSaveConfig(true, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureSaveConfig(true, true).configureEnterpriseClient();
 
-        boolean saved = context.getEnterpriseClient().saveConfig(
-                context.getExpectedAuthToken(),
-                "name" + UUID.randomUUID().toString(),
-                new URL("http://www.webscantest.com"),
+        boolean saved = context.getEnterpriseClient().saveConfig(context.getExpectedAuthToken(),
+                "name" + UUID.randomUUID().toString(), new URL("http://www.webscantest.com"),
                 "engine" + UUID.randomUUID().toString());
 
         assertTrue(saved);
@@ -342,30 +300,21 @@ class EnterpriseRestClientTest {
 
     @Test
     void saveConfigIsFalseWhenResultIsFail() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureSaveConfig(true, false)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureSaveConfig(true, false).configureEnterpriseClient();
 
-        boolean saved = context.getEnterpriseClient().saveConfig(
-                context.getExpectedAuthToken(),
-                "name" + UUID.randomUUID().toString(),
-                new URL("http://www.webscantest.com"),
+        boolean saved = context.getEnterpriseClient().saveConfig(context.getExpectedAuthToken(),
+                "name" + UUID.randomUUID().toString(), new URL("http://www.webscantest.com"),
                 "engine" + UUID.randomUUID().toString());
 
         assertFalse(saved);
     }
+
     @Test
     void saveConfigIsFalseWhenApiCallFails() throws IOException {
-        context
-            .arrangeExpectedValues()
-            .configureSaveConfig(false, true)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureSaveConfig(false, true).configureEnterpriseClient();
 
-        boolean saved = context.getEnterpriseClient().saveConfig(
-                context.getExpectedAuthToken(),
-                "name" + UUID.randomUUID().toString(),
-                new URL("http://www.webscantest.com"),
+        boolean saved = context.getEnterpriseClient().saveConfig(context.getExpectedAuthToken(),
+                "name" + UUID.randomUUID().toString(), new URL("http://www.webscantest.com"),
                 "engine" + UUID.randomUUID().toString());
 
         assertFalse(saved);
@@ -374,24 +323,21 @@ class EnterpriseRestClientTest {
     @Test
     void getVulnerabilitySummaryXmlIsPresentWhenSuccessful() throws IOException {
         String xml = String.format("<?xml><vulns id=\"%s\"></vulns>", UUID.randomUUID());
-        context
-            .arrangeExpectedValues()
-            .configureGetVulnerabilitiesSummaryXml(true, xml)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetVulnerabilitiesSummaryXml(true, xml).configureEnterpriseClient();
 
-        Optional<String> actualXml = context.getEnterpriseClient().getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<String> actualXml = context.getEnterpriseClient()
+                .getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
 
         assertTrue(actualXml.isPresent());
     }
+
     @Test
     void getVulnerabilitySummaryXmlCorrectResponseWhenSuccessful() throws IOException {
         String xml = String.format("<?xml><vulns id=\"%s\"></vulns>", UUID.randomUUID());
-        context
-                .arrangeExpectedValues()
-                .configureGetVulnerabilitiesSummaryXml(true, xml)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetVulnerabilitiesSummaryXml(true, xml).configureEnterpriseClient();
 
-        Optional<String> actualXml = context.getEnterpriseClient().getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<String> actualXml = context.getEnterpriseClient()
+                .getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
 
         assertEquals(xml, actualXml.orElse("wrong"));
     }
@@ -399,12 +345,10 @@ class EnterpriseRestClientTest {
     @Test
     void getVulnerabilitySummaryXmlIsNotPresentWhenFails() throws IOException {
         String xml = String.format("<?xml><vulns id=\"%s\"></vulns>", UUID.randomUUID());
-        context
-                .arrangeExpectedValues()
-                .configureGetVulnerabilitiesSummaryXml(false, xml)
-                .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetVulnerabilitiesSummaryXml(false, xml).configureEnterpriseClient();
 
-        Optional<String> actualXml = context.getEnterpriseClient().getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<String> actualXml = context.getEnterpriseClient()
+                .getVulnerabilitiesSummaryXml(context.getExpectedAuthToken(), context.getExpectedScanId());
 
         assertFalse(actualXml.isPresent());
     }
@@ -413,26 +357,23 @@ class EnterpriseRestClientTest {
     void getReportZipIsPresentWhenSuccessful() throws IOException {
         String content = UUID.randomUUID().toString();
         byte[] encodedContent = Base64.getEncoder().encode(content.getBytes());
-        context
-            .arrangeExpectedValues()
-            .configureGetReportZip(true, encodedContent)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetReportZip(true, encodedContent).configureEnterpriseClient();
 
-        Optional<InputStream> inputStream = context.getEnterpriseClient().getReportZip(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<InputStream> inputStream = context.getEnterpriseClient().getReportZip(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertTrue(inputStream.isPresent());
         inputStream.get().close();
     }
+
     @Test
     void getReportZipCorrectResultValueSuccessful() throws IOException {
         String content = UUID.randomUUID().toString();
         byte[] encodedContent = Base64.getEncoder().encode(content.getBytes());
-        context
-            .arrangeExpectedValues()
-            .configureGetReportZip(true, encodedContent)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetReportZip(true, encodedContent).configureEnterpriseClient();
 
-        Optional<InputStream> maybeInputStream = context.getEnterpriseClient().getReportZip(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<InputStream> maybeInputStream = context.getEnterpriseClient()
+                .getReportZip(context.getExpectedAuthToken(), context.getExpectedScanId());
         try (InputStream inputStream = maybeInputStream.orElseThrow(() -> new RuntimeException("test failure"))) {
             byte[] encodedResponse = new byte[inputStream.available()];
 
@@ -441,18 +382,46 @@ class EnterpriseRestClientTest {
             assertEquals(content, decoded);
         }
     }
+
     @Test
     void getReportZipIsNotPresentWhenFails() throws IOException {
         String content = UUID.randomUUID().toString();
         byte[] encodedContent = Base64.getEncoder().encode(content.getBytes());
-        context
-            .arrangeExpectedValues()
-            .configureGetReportZip(false, encodedContent)
-            .configureEnterpriseClient();
+        context.arrangeExpectedValues().configureGetReportZip(false, encodedContent).configureEnterpriseClient();
 
-        Optional<InputStream> inputStream = context.getEnterpriseClient().getReportZip(context.getExpectedAuthToken(), context.getExpectedScanId());
+        Optional<InputStream> inputStream = context.getEnterpriseClient().getReportZip(context.getExpectedAuthToken(),
+                context.getExpectedScanId());
 
         assertFalse(inputStream.isPresent());
     }
 
+    @Test
+    void getClientIdNamePairsIsPresentWhenSuccessful() throws IOException {
+        context
+            .arrangeExpectedValues()
+            .configureGetClientIdNamePairs(true)
+            .configureEnterpriseClient();
+
+        Optional<List<ClientIdNamePair>> configs = context
+            .getEnterpriseClient()
+            .getClientNameIdPairs(context.getExpectedAuthToken());
+
+        assertTrue(configs.isPresent());
+
+    }
+
+    @Test
+    void getClientIdNamePairsIsNotPresentWhenFail() throws IOException {
+        context
+            .arrangeExpectedValues()
+            .configureGetClientIdNamePairs(false)
+            .configureEnterpriseClient();
+
+        Optional<List<ClientIdNamePair>> configs = context
+            .getEnterpriseClient()
+            .getClientNameIdPairs(context.getExpectedAuthToken());
+
+        assertFalse(configs.isPresent());
+
+    }
 }


### PR DESCRIPTION
## Description
- added method to EnterpriseClient class to fetch id/name pairs of
clients, this will be used to populate the client id when authenticating
and to display the list of names for the user to choose when client,
that selection will then impact which scans are listed
- added AuthenticationModel model storing username, password and
optionally client Id as a first step towards multi-client
- updated EnterpriseClient to use AuthenticationModel for methods
taking username/password, any callers and tests have been updated
accordingly
- added storage for client name, this will be used to look up client
id, fortunately both are valid unique identifiers but other APIs require
the id
- UI now offers two drop downs, one for client and another for config,
upon selecting client the config drop down will reload (for the selected
client)
- added enable multi-client/system-admin support which requires
3.8.227 onwards, by default this is off which is compatible with
previous versions and 227+ for single-client users
- updated some of the help documents and added a new one for configName
- tweaks to populating the config name dialog to ensure it has a
selected item after loading

[ASE-4496 ASE Jenkins plugin does not work with Multi-Client account or SA account](https://issues.corp.rapid7.com/browse/ASE-4496)

## Testing

- saved configuration using local run via ```mvn hpi:run``` 
- verified complete run by installing to Jenkins instance running in docker

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
