### PR TITLE
ASE-4496 Added Retry for client id/names

### DIFF
--- a/src/main/java/com/rapid7/appspider/ContentHelper.java
+++ b/src/main/java/com/rapid7/appspider/ContentHelper.java
@@ -106,9 +106,11 @@ public class ContentHelper {
     /**
      * extracts the response content into a JSONObject
      * @param response response to extract JSONObject from
+     * @param path the path used for diagnostic purposes, this is the path to the 
+     *             request which can be logged in the event of failure
      * @return on success an Optional containing a JSONObject; otherwise, Optional.empty()
      */
-    public Optional<JSONObject> responseToJSONObject(HttpResponse response) {
+    public Optional<JSONObject> responseToJSONObject(HttpResponse response, String path) {
         if (isSuccessStatusCode(response)) {
             return asJson(response.getEntity());
         }

--- a/src/main/java/com/rapid7/appspider/HttpClientService.java
+++ b/src/main/java/com/rapid7/appspider/HttpClientService.java
@@ -50,7 +50,8 @@ public class HttpClientService implements ClientService {
     @Override
     public Optional<JSONObject> executeJsonRequest(HttpRequestBase request) {
         try {
-            return contentHelper.responseToJSONObject(httpClient.execute(request));
+            
+            return contentHelper.responseToJSONObject(httpClient.execute(request), request.getURI().getPath());
 
         } catch (IOException e) {
             logger.severe(e.toString());


### PR DESCRIPTION
## Description
- updated to add one extra attempt to fetch id/names
- improved log messages for failed requests, should now include the
request path so we see which endpoint was hit (but not the host or query
parameters)
<!-- Add JIRA link if applicable -->

## Testing
- setup config in fresh docker instance
- setup config in existing docker instance
- ran scan to completion (in docker instance of Jenkins)

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
